### PR TITLE
Correção no regex

### DIFF
--- a/replace-uploads-url.php
+++ b/replace-uploads-url.php
@@ -66,7 +66,7 @@ class Replace_Uploads_Url {
 
     public function replace( $content ) {
         preg_match_all(
-            "#(https?:\/\/){$this->get_domain_host()}[/|.|\w|-]*\.(jpe?g|gif|png|svg)#",
+            "#(https?:\/\/){$this->get_domain_host()}[^.]*\.(jpe?g|gif|png|svg)#",
             $content,
             $images_match
         );


### PR DESCRIPTION
Haviam URL de imagens que não era comtemplados neste regex, por causa dos caracteres especiais: Ex. `Card_institui%C3%A7%C3%B5es_de_ensino-231x300.png`